### PR TITLE
Multiple init

### DIFF
--- a/examples/multi.cml
+++ b/examples/multi.cml
@@ -18,5 +18,5 @@ def alloc_two y =
     let del_two = delay {cl(wait keyboard)} y in
     delay {cl(del_two)} (advance del_two);
 
-out_one <- alloc_one 2;
-out_two <- alloc_two 69;
+print <- alloc_one 2;
+print <- alloc_one 69;

--- a/src/anf.rs
+++ b/src/anf.rs
@@ -85,7 +85,7 @@ impl AnfExpr {
 pub enum AnfToplevel {
     FunDef(Sym, Vec<(Sym, Type)>, AnfExpr, Type),
     Channel(String, Type),
-    Output(String, AExpr),
+    Output(String, AnfExpr),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,7 +1,7 @@
 pub mod anf_wasm;
 pub mod wasm_emitter;
 
-pub fn compile_anf_to_wasm(prog: &crate::anf::AnfProg) -> Vec<u8> {
+pub fn compile_anf_to_wasm(prog: &crate::anf::AnfProg) -> (Vec<u8>, Vec<String>) {
     let emitter = anf_wasm::AnfWasmEmitter::new(prog);
     emitter.emit()
 }

--- a/src/backend/wasm_emitter.rs
+++ b/src/backend/wasm_emitter.rs
@@ -41,14 +41,18 @@ pub const LOCATION_HEAP_INDEX: u32 = 1;
 
 // const MALLOC_ARGS: [(&str, Type); 1] = [("size", Type::TInt)];
 pub const WAIT_FUN_IDX: u32 = 0;
-const MALLOC_FUN_IDX: u32 = 1;
-const LOCATION_MALLOC_FUN_IDX: u32 = 2;
-pub const CLOCK_OF_FUN_IDX: u32 = 3;
+pub const SET_OUTPUT_TO_LOCATION_IDX: u32 = 1;
+const MALLOC_FUN_IDX: u32 = 2;
+const LOCATION_MALLOC_FUN_IDX: u32 = 3;
+pub const CLOCK_OF_FUN_IDX: u32 = 4;
 
 const PREGEN_MODULE: &str = r#"
 (module
     (type $wait (func (param i32) (result i32)))
     (import "ffi" "wait" (func $wait (type $wait)))
+
+    (type $set_output_to_location (func (param i32 i32) (result i32)))
+    (import "ffi" "set_output_to_location" (func $set_output_to_location (type $set_output_to_location)))
 
     (global $next_ptr (mut i32) (i32.const 0))
     (global $next_location (mut i32) (i32.const 0))
@@ -202,6 +206,18 @@ impl WasmEmitter<'_> {
         self.func_map.insert("wait", WAIT_FUN_IDX);
         self.func_args.insert("wait", vec![("channel", Type::TInt)]);
         self.type_map.insert("wait", WAIT_FUN_IDX);
+
+        self.func_map
+            .insert("set_output_to_location", SET_OUTPUT_TO_LOCATION_IDX);
+        self.func_args.insert(
+            "set_output_to_location",
+            vec![
+                ("output_channel_index", Type::TInt),
+                ("location_ptr", Type::TInt),
+            ],
+        );
+        self.type_map
+            .insert("set_output_to_location", SET_OUTPUT_TO_LOCATION_IDX);
 
         self.func_map.insert("malloc", MALLOC_FUN_IDX);
         self.func_args.insert("malloc", vec![("size", Type::TInt)]);

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -65,28 +65,30 @@ fn main() -> Result<(), lexopt::Error> {
 
     let prog = infer_all(prog);
     let wasm_bytes;
+    let output_channels;
 
     let channels = prog.1.clone();
-    if let Ok(bytes) = compile_and_write_prog(prog) {
+    if let Ok((bytes, names)) = compile_and_write_prog(prog) {
         wasm_bytes = bytes;
+        output_channels = names;
     } else {
         panic!("Failed to compile and write oopsies");
     }
 
     if args.run {
-        let machine = Runtime::init(&wasm_bytes, channels);
+        let machine = Runtime::init(&wasm_bytes, channels, output_channels);
         machine.run();
     }
 
     Ok(())
 }
 
-fn compile_and_write_prog(prog: TypedProg) -> Result<Vec<u8>, lexopt::Error> {
+fn compile_and_write_prog(prog: TypedProg) -> Result<(Vec<u8>, Vec<String>), lexopt::Error> {
     let prog = run_program_passes_anf(prog);
-    let res = compile_anf_to_wasm(&prog);
+    let (res, names) = compile_anf_to_wasm(&prog);
     let mut stdout = std::io::stdout().lock();
     stdout.write_all(&res).unwrap();
     eprintln!();
 
-    Ok(res)
+    Ok((res, names))
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,4 +1,4 @@
-use std::fmt::{write, Display};
+use std::fmt::Display;
 
 use itertools::Itertools;
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -81,6 +81,7 @@ impl Prog {
                     let mut pairs = pair.into_inner();
                     let name = pairs.next().unwrap().as_str().to_string();
                     let expr = parse_expression(pairs.next().unwrap().into_inner());
+                    dbg!(&expr);
                     toplevels.push(Toplevel::Output(name, expr));
                 }
                 Rule::EOI => break,

--- a/src/passes/anf.rs
+++ b/src/passes/anf.rs
@@ -130,8 +130,9 @@ impl Pass<TypedProg, AnfProg> for ANFConversion {
                 }
                 TypedToplevel::Channel(chan, typ) => AnfToplevel::Channel(chan, typ),
                 TypedToplevel::Output(name, body) => {
-                    let (aexpr, _) = self.normalize_atom(*body);
-                    AnfToplevel::Output(name, aexpr)
+                    // let (aexpr, bindings) = self.normalize_atom(*body);
+                    let anf_body = self.normalize(*body);
+                    AnfToplevel::Output(name, anf_body)
                 }
             })
             .collect();


### PR DESCRIPTION
This also changes AnfToplevel::Output to contain an AnfExpr instead of AExpr. This makes it possible for outputs to depend on ANYTHING which me might want to restrict somehow.